### PR TITLE
Enhance usability of ModelZoo-YOLOv5

### DIFF
--- a/auto_process.py
+++ b/auto_process.py
@@ -2,6 +2,7 @@ import os
 import argparse
 import shutil
 
+import yaml
 import torch
 import torch.fx as fx
 from loguru import logger
@@ -165,9 +166,18 @@ if __name__ == '__main__':
     head_path = '.'.join(OUTPUT_PATH.split('.')[:-1]) + '_head.pt'
     torch.save(head, head_path)
 
+    with open(args.hyp) as f:
+        hyp = yaml.safe_load(f)
+        hyp['lr0'] *= 0.1
+    
+    with open('tmp_hyp.yaml', 'w') as f:
+        yaml.safe_dump(hyp, f)
+    args.hyp = 'tmp_hyp.yaml'
+
     run_input = {'netspresso': True, 'weights': backbone_path, **args.__dict__}
     train_opt = train.run(**run_input)
 
+    os.remove(args.hyp)
     logger.info("Fine-tuning step end.")
 
     """ 

--- a/auto_process.py
+++ b/auto_process.py
@@ -27,7 +27,7 @@ def parse_args():
     parser.add_argument('-w', '--weight_path', type=str)
     parser.add_argument("--compression_method", type=str, choices=["PR_L2", "PR_GM", "PR_NN", "PR_ID", "FD_TK", "FD_CP", "FD_SVD"], default="PR_L2")
     parser.add_argument("--recommendation_method", type=str, choices=["slamp", "vbmf"], default="slamp")
-    parser.add_argument("--compression_ratio", type=int, default=0.5)
+    parser.add_argument("--compression_ratio", type=int, default=0.3)
     parser.add_argument("-m", "--np_email", help="NetsPresso login e-mail", type=str)
     parser.add_argument("-p", "--np_password", help="NetsPresso login password", type=str)
 

--- a/auto_process.py
+++ b/auto_process.py
@@ -4,6 +4,8 @@ import torch
 import torch.fx as fx
 from loguru import logger
 
+from netspresso.compressor import ModelCompressor, Task, Framework
+
 
 def parse_args():
     parser = argparse.ArgumentParser()
@@ -17,6 +19,16 @@ def parse_args():
         Compression arguments
     """
     parser.add_argument('-w', '--weight_path', type=str)
+    parser.add_argument("--compression_method", type=str, choices=["PR_L2", "PR_GM", "PR_NN", "PR_ID", "FD_TK", "FD_CP", "FD_SVD"], default="PR_L2")
+    parser.add_argument("--recommendation_method", type=str, choices=["slamp", "vbmf"], default="slamp")
+    parser.add_argument("--compression_ratio", type=int, default=0.5)
+    parser.add_argument("-m", "--np_email", help="NetsPresso login e-mail", type=str)
+    parser.add_argument("-p", "--np_password", help="NetsPresso login password", type=str)
+
+    """
+        Fine-tuning arguments
+    """
+    parser.add_argument('--imgsz', '--img', '--img-size', type=int, default=640, help='train, val image size (pixels)')
 
     return parser.parse_args()
 
@@ -30,7 +42,7 @@ if __name__ == '__main__':
     logger.info("yolov5 to fx graph start.")
 
     model = torch.load(args.weight_path, map_location='cpu')
-    
+
     #save model_torchfx.pt
     if isinstance(model, torch.nn.Sequential):
         model.train()
@@ -46,7 +58,45 @@ if __name__ == '__main__':
         _graph = fx.Tracer().trace(model, {'augment': False, 'profile':False, 'visualize':False})
         model = fx.GraphModule(model, _graph)
 
+    model.float()
+    model_head.float()
     torch.save(model, f'{args.name}_fx.pt')
     torch.save(model_head, f'{args.name}_head_fx.pt')
     
     logger.info("yolov5 to fx graph end.")
+
+    """
+        Model compression - recommendation compression 
+    """
+    logger.info("Compression step start.")
+    
+    compressor = ModelCompressor(email=args.np_email, password=args.np_password)
+
+    UPLOAD_MODEL_NAME = args.name
+    TASK = Task.OBJECT_DETECTION
+    FRAMEWORK = Framework.PYTORCH
+    UPLOAD_MODEL_PATH = args.name + '_fx.pt'
+    INPUT_SHAPES = [{"batch": 1, "channel": 3, "dimension": (args.imgsz, args.imgsz)}]
+    model = compressor.upload_model(
+        model_name=UPLOAD_MODEL_NAME,
+        task=TASK,
+        framework=FRAMEWORK,
+        file_path=UPLOAD_MODEL_PATH,
+        input_shapes=INPUT_SHAPES,
+    )
+
+    COMPRESSION_METHOD = args.compression_method
+    RECOMMENDATION_METHOD = args.recommendation_method
+    RECOMMENDATION_RATIO = args.compression_ratio
+    COMPRESSED_MODEL_NAME = f'{UPLOAD_MODEL_NAME}_{COMPRESSION_METHOD}_{RECOMMENDATION_RATIO}'
+    OUTPUT_PATH = COMPRESSED_MODEL_NAME + '.pt'
+    compressed_model = compressor.recommendation_compression(
+        model_id=model.model_id,
+        model_name=COMPRESSED_MODEL_NAME,
+        compression_method=COMPRESSION_METHOD,
+        recommendation_method=RECOMMENDATION_METHOD,
+        recommendation_ratio=RECOMMENDATION_RATIO,
+        output_path=OUTPUT_PATH,
+    )
+
+    logger.info("Compression step end.")

--- a/auto_process.py
+++ b/auto_process.py
@@ -6,6 +6,8 @@ from loguru import logger
 
 from netspresso.compressor import ModelCompressor, Task, Framework
 
+import train
+
 
 def parse_args():
     parser = argparse.ArgumentParser()
@@ -28,7 +30,44 @@ def parse_args():
     """
         Fine-tuning arguments
     """
+    parser.add_argument('--cfg', type=str, default='', help='model.yaml path')
+    parser.add_argument('--data', type=str, default='data/coco128.yaml', help='dataset.yaml path')
+    parser.add_argument('--hyp', type=str, default='data/hyps/hyp.scratch-low.yaml', help='hyperparameters path')
+    parser.add_argument('--epochs', type=int, default=100, help='total training epochs')
+    parser.add_argument('--batch-size', type=int, default=16, help='total batch size for all GPUs, -1 for autobatch')
     parser.add_argument('--imgsz', '--img', '--img-size', type=int, default=640, help='train, val image size (pixels)')
+    parser.add_argument('--rect', action='store_true', help='rectangular training')
+    parser.add_argument('--resume', nargs='?', const=True, default=False, help='resume most recent training')
+    parser.add_argument('--nosave', action='store_true', help='only save final checkpoint')
+    parser.add_argument('--noval', action='store_true', help='only validate final epoch')
+    parser.add_argument('--noautoanchor', action='store_true', help='disable AutoAnchor')
+    parser.add_argument('--noplots', action='store_true', help='save no plot files')
+    parser.add_argument('--evolve', type=int, nargs='?', const=300, help='evolve hyperparameters for x generations')
+    parser.add_argument('--bucket', type=str, default='', help='gsutil bucket')
+    parser.add_argument('--cache', type=str, nargs='?', const='ram', help='image --cache ram/disk')
+    parser.add_argument('--image-weights', action='store_true', help='use weighted image selection for training')
+    parser.add_argument('--device', default='0', help='cuda device, i.e. 0 or 0,1,2,3 or cpu')
+    parser.add_argument('--multi-scale', action='store_true', help='vary img-size +/- 50%%')
+    parser.add_argument('--single-cls', action='store_true', help='train multi-class data as single-class')
+    parser.add_argument('--optimizer', type=str, choices=['SGD', 'Adam', 'AdamW'], default='SGD', help='optimizer')
+    parser.add_argument('--sync-bn', action='store_true', help='use SyncBatchNorm, only available in DDP mode')
+    parser.add_argument('--workers', type=int, default=8, help='max dataloader workers (per RANK in DDP mode)')
+    parser.add_argument('--project', default='runs/train', help='save to project/name')
+    parser.add_argument('--exist-ok', action='store_true', help='existing project/name ok, do not increment')
+    parser.add_argument('--quad', action='store_true', help='quad dataloader')
+    parser.add_argument('--cos-lr', action='store_true', help='cosine LR scheduler')
+    parser.add_argument('--label-smoothing', type=float, default=0.0, help='Label smoothing epsilon')
+    parser.add_argument('--patience', type=int, default=100, help='EarlyStopping patience (epochs without improvement)')
+    parser.add_argument('--freeze', nargs='+', type=int, default=[0], help='Freeze layers: backbone=10, first3=0 1 2')
+    parser.add_argument('--save-period', type=int, default=-1, help='Save checkpoint every x epochs (disabled if < 1)')
+    parser.add_argument('--seed', type=int, default=0, help='Global training seed')
+    parser.add_argument('--local_rank', type=int, default=-1, help='Automatic DDP Multi-GPU argument, do not modify')
+
+    # Logger arguments
+    parser.add_argument('--entity', default=None, help='Entity')
+    parser.add_argument('--upload_dataset', nargs='?', const=True, default=False, help='Upload data, "val" option')
+    parser.add_argument('--bbox_interval', type=int, default=-1, help='Set bounding-box image logging interval')
+    parser.add_argument('--artifact_alias', type=str, default='latest', help='Version of dataset artifact to use')
 
     return parser.parse_args()
 
@@ -61,7 +100,7 @@ if __name__ == '__main__':
     model.float()
     model_head.float()
     torch.save(model, f'{args.name}_fx.pt')
-    torch.save(model_head, f'{args.name}_head_fx.pt')
+    torch.save(model_head, f'{args.name}_head.pt')
     
     logger.info("yolov5 to fx graph end.")
 
@@ -100,3 +139,23 @@ if __name__ == '__main__':
     )
 
     logger.info("Compression step end.")
+
+    """
+        Retrain YOLOv5 model
+    """
+    logger.info("Fine-tuning step start.")
+
+    backbone_path = OUTPUT_PATH
+    backbone = torch.load(backbone_path, map_location='cpu')
+    backbone_path = '.'.join(backbone_path.split('.')[:-1]) + '_backbone.pt'
+    torch.save(backbone, backbone_path)
+
+    head_path = f'{args.name}_head.pt'
+    head = torch.load(head_path, map_location='cpu')
+    head_path = '.'.join(OUTPUT_PATH.split('.')[:-1]) + '_head.pt'
+    torch.save(head, head_path)
+
+    run_input = {'netspresso': True, 'weights': backbone_path, **args.__dict__}
+    train.run(**run_input)
+
+    logger.info("Fine-tuning step end.")

--- a/auto_process.py
+++ b/auto_process.py
@@ -1,0 +1,52 @@
+import argparse
+
+import torch
+import torch.fx as fx
+from loguru import logger
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+
+    """
+        Compression arguments
+    """
+    parser.add_argument('-n', '--name', type=str)
+
+    """
+        Compression arguments
+    """
+    parser.add_argument('-w', '--weight_path', type=str)
+
+    return parser.parse_args()
+
+
+if __name__ == '__main__':
+    args = parse_args()
+
+    """ 
+        Convert YOLOX model to fx 
+    """
+    logger.info("yolov5 to fx graph start.")
+
+    model = torch.load(args.weight_path, map_location='cpu')
+    
+    #save model_torchfx.pt
+    if isinstance(model, torch.nn.Sequential):
+        model.train()
+        model[-1].export = False
+        model_head = model[-1]
+        model = model[0]        
+    else:
+        model = model['model']
+        model.train()
+        model.model[-1].export = False
+        model_head = model.model[-1]
+        
+        _graph = fx.Tracer().trace(model, {'augment': False, 'profile':False, 'visualize':False})
+        model = fx.GraphModule(model, _graph)
+
+    torch.save(model, f'{args.name}_fx.pt')
+    torch.save(model_head, f'{args.name}_head_fx.pt')
+    
+    logger.info("yolov5 to fx graph end.")

--- a/auto_process.py
+++ b/auto_process.py
@@ -17,7 +17,7 @@ def parse_args():
     parser = argparse.ArgumentParser()
 
     """
-        Compression arguments
+        Common arguments
     """
     parser.add_argument('-n', '--name', type=str)
 
@@ -87,7 +87,7 @@ if __name__ == '__main__':
         assert args.device != 'cpu', "Cannot export model to fp16 onnx with cpu mode!!"
 
     """ 
-        Convert YOLOX model to fx 
+        Convert YOLOv5 model to fx 
     """
     logger.info("yolov5 to fx graph start.")
 
@@ -181,7 +181,7 @@ if __name__ == '__main__':
     logger.info("Fine-tuning step end.")
 
     """ 
-        Export PIDNet model to onnx
+        Export YOLOv5 model to onnx
     """
     logger.info("Export model to onnx format step start.")
     


### PR DESCRIPTION
Slack link: https://nota-workspace.slack.com/archives/C040F65LSAJ/p1692766946904609
Notion link: https://www.notion.so/notaai/YOLOv5-2c1258b1cdcd4d749b99aaac58200da4?pvs=4

목적
---
ModelZoo에서 세분화된 기능을 하나로 합쳐서 하나의 파일만 실행하면 경량화 → 재학습 → onnx export까지 되어 LaunchX 사용 가능하게 한다.

변경 사항
---
- auto_process.py 파일을 생성했습니다. fx 변환, 경량화, 재학습, onnx 변환 이라는 단계를 거치며, 이를 위해 다음과 같은 argument를 받습니다.
  - 모델 이름 (ex. yolov5s)
  - 모델 weight path (ex. yolov5s.pt)
  - NetsPresso 계정 이메일
  - NetsPresso 계정 비밀번호
  - 그 외의 argument 들을 추가로 사용할 수 있으나, default 로도 사용 가능합니다.
- 최대한 기존 코드의 수정을 막기 위해, 필요한 코드들을 가져와 순서대로 작동하도록 구성했습니다.
- 코드 실행으로 발생하는 fx와 onnx 파일은 `root` 디렉토리에 생성됩니다.
  - `{name}_{compression_method}_{compression_ratio}.pt`와 `{name}_head.pt` 파일을 train 함수에서 받을 수 있도록 이름 규칙을 지키는 형태로 복사하는 과정이 있습니다.
- 테스트
  - pytorch 버전과 관련한 issue로 인해 pretrained 모델을 공식 레포에서 다운받은 후, 제 환경에서 사용할 수 있게 하기 위해 load 와 save 과정을 한번 더 거쳐서 사용했습니다.
  - `python auto_process.py -n yolov5s -w yolov5s.pt --np_email {email} --np_password {password}`
  - `python auto_process.py -n yolov5n -w yolov5n.pt --np_email {email} --np_password {password}`