### PR TITLE
fix anchor_grid size in detect_infer class

### DIFF
--- a/models/yolo.py
+++ b/models/yolo.py
@@ -105,8 +105,8 @@ class Detect_infer(nn.Module):
         self.nl = len(anchors)  # number of detection layers
         self.na = len(anchors[0]) // 2  # number of anchors
         self.grid = [torch.empty(0) for _ in range(self.nl)]  # init grid
-        self.anchor_grid = [torch.empty(0) for _ in range(self.nl)]  # init anchor grid
         self.register_buffer('anchors', torch.tensor(anchors).float().view(self.nl, -1, 2))  # shape(nl,na,2)
+        self.register_buffer('anchor_grid', torch.tensor(anchors).float().view(self.nl, 1, -1, 1, 1, 2))  # shape(nl,1,na,1,1,2)
         self.inplace = inplace  # use inplace ops (e.g. slice assignment)
 
     def forward(self, x):


### PR DESCRIPTION
Slack link: https://nota-workspace.slack.com/archives/C048ELT7V9N/p1698222326943069

목적
---
yolo-fastest 모델을 학습 후 validation 시 발생하는 에러를 fix하기 위해 만들었습니다.

변경 사항
---
- anchor_grid와 y의 shape이 맞지 않아 맞는 shape으로 초기화 시켜주었습니다.